### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###Changelog:
+### Changelog:
 v0.2.0:
 
 1. CSS overrides to allow unresponsive top navbar menu items with the 'navbar-static' class (refer index.html)
@@ -18,7 +18,7 @@ A responsive sidebar plugin for bootstrap 3. if your menus are too big to fit in
 (NOTE: Contributions are welcome! please issue a Pull Request)
 
 
-###Features:
+### Features:
 
 1. Hardware accelerated slide-in animation
 2. You can set the sidebar to be permanently open for any screen size
@@ -27,7 +27,7 @@ A responsive sidebar plugin for bootstrap 3. if your menus are too big to fit in
 4. Right and Left sidebars now work.
 5. CSS overrides for top navbar to allow menu items to stay visible and not responsive when in smaller screens 
 
-###Current Limitations: 
+### Current Limitations: 
 
 1. This sidebar assumes you have a fixed top menubar
 2. This sidebar assumes you are using the 'container-fluid' class. use the affix plugin or a normal vertical menu for a fixed-width setup. 
@@ -36,15 +36,15 @@ A responsive sidebar plugin for bootstrap 3. if your menus are too big to fit in
 5. ~~Clicking outside the sidebar does not close the sidebar in smaller screens.~~
 6. ~~On larger screens the sidebar is open(visible) by default and there is no way to change this at the moment.~~ 
 
-###Demo:
+### Demo:
 
 view plunker demo here: http://run.plnkr.co/plunks/sA6H7U/
 
-#####OR
+##### OR
 
 open index.html on your browser to checkout the features
 
-###Installation:
+### Installation:
 
 Install using bower:
 
@@ -54,7 +54,7 @@ bower install bootstrap-sidebar
 
 or download a zip copy of this repo 
 
-###Usage:
+### Usage:
 
 Usage is almost the same as the horizontal menubar collapse method: define a button on your top menubar that toggles the sidebar on and off like this:
 
@@ -77,14 +77,14 @@ then define your sidebar column as:
 </div>
 ```
 
-#####Note the important classes: 
+##### Note the important classes: 
 
 * "sidebar" - main css class
 * "sidebar-left" - to define the position of your sidebar and slide-in slide-out animations. Options are: sidebar-left, sidebar-right
 * "sidebar-animation" - (Optional) to tell sidebar to animate sliding in and out.
 * "col-xs-7", "col-sm-3", "col-md-2" - you can freely set the sidebar column sizes across different screen sizes according to Bootstrap's Grid guidelines
 
-###Defining permanent sidebars:
+### Defining permanent sidebars:
 
 To define a sidebar that displays permanently for a certain screen size (in this example, for sizes md and above):
 
@@ -102,7 +102,7 @@ make sure your main content area is defined as follows:
 </div>
 ```
 
-#####Note the important classes:
+##### Note the important classes:
 
 1. In the sidebar div:
   * "sidebar-md-show" - tells the sidebar to be permanently open. 'md' refers to the screen size you want the sidebar to be permanently open at (options are: xs, sm, md, lg as per bootstrap 3 conventions). make sure you set your column sizes accordingly to accomodate a permanent sidebar. 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
